### PR TITLE
Add `RETURNING` support to connection's `update` method

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2019-03-22  Kirit Saelensminde  <kirit@felspar.com>
+ Add `RETURNING` support to connection's `update` method.
+
 2017-11-08  Kirit Saelensminde  <kirit@felspar.com>
  Put session variable names in double quotes.
 

--- a/Cpp/fost-postgres/connection.cpp
+++ b/Cpp/fost-postgres/connection.cpp
@@ -231,6 +231,14 @@ fostlib::pg::recordset fostlib::pg::connection::insert(
 
 fostlib::pg::connection &fostlib::pg::connection::update(
         const char *relation, const json &keys, const json &values) {
+    update(relation, keys, values, {});
+    return *this;
+}
+fostlib::pg::recordset fostlib::pg::connection::update(
+        const char *relation,
+        const json &keys,
+        const json &values,
+        const std::vector<fostlib::string> &returning) {
     string sql("UPDATE "), updates, where;
     sql += relation;
     sql += " SET ";
@@ -253,8 +261,11 @@ fostlib::pg::connection &fostlib::pg::connection::update(
         }
     }
     sql += updates + " WHERE " + where;
-    exec(coerce<utf8_string>(sql));
-    return *this;
+    if (returning.size()) {
+        auto ret_vals = returning_vals(returning);
+        sql += " RETURNING " + ret_vals;
+    }
+    return exec(coerce<utf8_string>(sql));
 }
 
 

--- a/Cpp/include/fost/pg/connection.hpp
+++ b/Cpp/include/fost/pg/connection.hpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2015-2016, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2015-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -81,9 +81,14 @@ namespace fostlib {
                     insert(const char *relation,
                            const json &values,
                            const std::vector<fostlib::string> &returning);
-            /// Performa one row UPDATE statement. Give the keys and values
+            /// Perform a one row UPDATE statement. Give the keys and values
             connection &update(
                     const char *relation, const json &keys, const json &values);
+            recordset
+                    update(const char *relation,
+                           const json &keys,
+                           const json &values,
+                           const std::vector<fostlib::string> &returning);
             /// Perform an UPSERT (INSERT/CONFLICT). Give the keys and values
             /// and optionally a returning list
             connection &upsert(


### PR DESCRIPTION
This allows us to more efficiently return data from `UPDATE`s and to check that the `UPDATE` actually did anything, and what it operated on, by returning the altered data rows.