### PR TITLE
Libpqxx7

### DIFF
--- a/Cpp/fost-postgres/connection.cpp
+++ b/Cpp/fost-postgres/connection.cpp
@@ -32,7 +32,7 @@ namespace {
                 fostlib::insert(effective, key, conf[key]);
                 dsn += fostlib::utf8_string(key) + "='"
                         + fostlib::coerce<fostlib::utf8_string>(
-                                  fostlib::coerce<fostlib::string>(conf[key]))
+                                fostlib::coerce<fostlib::string>(conf[key]))
                         + "' ";
             }
         }

--- a/Cpp/fost-postgres/recordset.cpp
+++ b/Cpp/fost-postgres/recordset.cpp
@@ -167,15 +167,15 @@ fostlib::pg::recordset::const_iterator::const_iterator()
 fostlib::pg::recordset::const_iterator::const_iterator(
         const const_iterator &other)
 : pimpl(new impl(
-          other.pimpl->rs, other.pimpl->position, other.pimpl->row.size())) {
+        other.pimpl->rs, other.pimpl->position, other.pimpl->row.size())) {
     pimpl->row = other.pimpl->row;
 }
 fostlib::pg::recordset::const_iterator::const_iterator(
         recordset::impl &rs, bool begin)
 : pimpl(new impl(
-          &rs,
-          begin ? rs.records.begin() : rs.records.end(),
-          rs.records.columns())) {
+        &rs,
+        begin ? rs.records.begin() : rs.records.end(),
+        rs.records.columns())) {
     if (pimpl->position != rs.records.end()) {
         fillin(rs.types, pimpl->position, pimpl->row.fields);
     }

--- a/Cpp/include/fost/pg/stored-procedure.hpp
+++ b/Cpp/include/fost/pg/stored-procedure.hpp
@@ -1,8 +1,8 @@
-/*
-    Copyright 2016, Felspar Co Ltd. http://support.felspar.com/
+/**
+    Copyright 2016-2019, Felspar Co Ltd. <http://support.felspar.com/>
+
     Distributed under the Boost Software License, Version 1.0.
-    See accompanying file LICENSE_1_0.txt or copy at
-        http://www.boost.org/LICENSE_1_0.txt
+    See <http://www.boost.org/LICENSE_1_0.txt>
 */
 
 
@@ -32,7 +32,7 @@ namespace fostlib {
           public:
             const std::string name;
 
-            recordset exec(const std::vector<fostlib::string> &args);
+            recordset exec(std::vector<fostlib::string> args);
             recordset exec(const std::vector<fostlib::json> &args);
         };
 


### PR DESCRIPTION
The old APis that we were using for handling runtime variable argument lists for prepared statements are no longer supported. Unfortunately we have severe impedance mismatch between our data structures and the APIs. This has been raised at https://github.com/jtv/libpqxx/issues/184