### PR TITLE
Libpqxx7

### DIFF
--- a/Cpp/fost-postgres-test/pg.cpp
+++ b/Cpp/fost-postgres-test/pg.cpp
@@ -52,7 +52,8 @@ namespace {
         FSL_CHECK(records.begin() != records.end());
         FSL_CHECK(++records.begin() == records.end());
     }
-    // We don't care about the table, we want to test the transformation and it shouldn't throw an error
+    // We don't care about the table, we want to test the transformation and it
+    // shouldn't throw an error
     void use_value_in_where_clause(fostlib::json const target) {
         fostlib::json values;
         fostlib::insert(values, "table_name", target);

--- a/Cpp/fost-postgres/stored-procedure.cpp
+++ b/Cpp/fost-postgres/stored-procedure.cpp
@@ -14,19 +14,16 @@
 
 
 namespace {
-    template<typename Iter, typename Func>
+    template<typename Coll, typename Func>
     auto exec_prepared(
             pqxx::transaction<pqxx::serializable> &trans,
             std::string const &name,
-            Iter begin,
-            Iter end,
+            Coll &collection,
             Func transform) {
-        std::vector<char const *> dynargs;
-        std::transform(begin, end, std::back_inserter(dynargs), transform);
         return trans.exec_prepared(
                 name,
                 pqxx::prepare::make_dynamic_params(
-                        dynargs.begin(), dynargs.end()));
+                        collection, transform));
     }
 }
 
@@ -39,7 +36,7 @@ fostlib::pg::unbound_procedure::unbound_procedure(
 fostlib::pg::recordset fostlib::pg::unbound_procedure::exec(
         std::vector<fostlib::string> args) {
     return recordset(std::make_unique<recordset::impl>(exec_prepared(
-            *cnx.pimpl->trans, name, args.begin(), args.end(),
+            *cnx.pimpl->trans, name, args,
             [](fostlib::string &arg) { return arg.shrink_to_fit(); })));
 }
 
@@ -58,7 +55,7 @@ fostlib::pg::recordset fostlib::pg::unbound_procedure::exec(
                 }
             });
     return recordset(std::make_unique<recordset::impl>(exec_prepared(
-            *cnx.pimpl->trans, name, args.begin(), args.end(), [](auto &arg) {
+            *cnx.pimpl->trans, name, args, [](auto &arg) {
                 return arg.has_value() ? arg.value().c_str() : nullptr;
             })));
 }

--- a/Cpp/fost-postgres/stored-procedure.cpp
+++ b/Cpp/fost-postgres/stored-procedure.cpp
@@ -22,8 +22,7 @@ namespace {
             Func transform) {
         return trans.exec_prepared(
                 name,
-                pqxx::prepare::make_dynamic_params(
-                        collection, transform));
+                pqxx::prepare::make_dynamic_params(collection, transform));
     }
 }
 
@@ -54,8 +53,8 @@ fostlib::pg::recordset fostlib::pg::unbound_procedure::exec(
                             fostlib::coerce<fostlib::string>(arg));
                 }
             });
-    return recordset(std::make_unique<recordset::impl>(exec_prepared(
-            *cnx.pimpl->trans, name, args, [](auto &arg) {
+    return recordset(std::make_unique<recordset::impl>(
+            exec_prepared(*cnx.pimpl->trans, name, args, [](auto &arg) {
                 return arg.has_value() ? arg.value().c_str() : nullptr;
             })));
 }


### PR DESCRIPTION
This change removes a few extra memory allocations that were needed until libpqxx updated.

This also shows that https://github.com/jtv/libpqxx/issues/184 can be closed.